### PR TITLE
Support spaces in filepaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,29 @@
 
 From the linux man pages (<https://man7.org/linux/man-pages/man7/inotify.7.html>):
 
-*The inotify API provides a mechanism for monitoring filesystem events. Inotify can be used to monitor individual files, or to monitor directories. When a directory is monitored, inotify will return events for the directory itself, and for files inside the directory.*
+*The inotify API provides a mechanism for monitoring filesystem events. Inotify can be used to
+monitor individual files, or to monitor directories. When a directory is monitored, inotify will
+return events for the directory itself, and for files inside the directory.*
 
-Two command-line tools are distributed as part of the `inotify-tools` package (`inotifywait`, `inotifywatch`) and allows to interact with the Inotify API.
+Two command-line tools are distributed as part of the `inotify-tools` package (`inotifywait`,
+`inotifywatch`) and allows to interact with the Inotify API.
 
 ## How to use this image
 
-`docker-inotify` provides an Alpine-based image that contains the `inotify-tools` package, as well as `bash` and a series of network-related command-line utilities such as `curl`, `netcat`, etc. It also includes a lightweight `inotifywait.sh` script that can watch files and/or directories and send events to a user-defined script. The script can be entirely configured through environment variables.
+`docker-inotify` provides an Alpine-based image that contains the `inotify-tools` package, as well
+as `bash` and a series of network-related command-line utilities such as `curl`, `netcat`, etc. It
+also includes a lightweight `inotifywait.sh` script that can watch files and/or directories and send
+events to a user-defined script. The script can be entirely configured through environment
+variables.
 
-The main use-case for this image is to provide an easy way to trigger an action based on a configuration file change. All you need to do is mount a volume in the sidecar to be monitored, and provide a script to trigger when an event is received.
+The main use-case for this image is to provide an easy way to trigger an action based on a
+configuration file change. All you need to do is mount a volume in the sidecar to be monitored, and
+provide a script to trigger when an event is received.
 
 ### How it works
 
-An `inotifywait` process watches INOTIFY_TARGET, and runs INOTIFY_SCRIPT with the triggered event data as arguments.
+An `inotifywait` process watches INOTIFY_TARGET, and runs INOTIFY_SCRIPT with the triggered event
+data as arguments.
 
 When using the default configuration values, the script will receive:
 
@@ -43,8 +53,8 @@ When using the default configuration values, the script will receive:
 | ---- | --------------------------------------- |
 | `$1` | timestamp                               |
 | `$2` | watched file/directory path             |
-| `$3` | event names                             |
-| `$4` | filenames (if a directory is monitored) |
+| `$3` | event name(s)                           |
+| `$4` | filename (if a directory is monitored)  |
 
 #### Arguments examples
 
@@ -78,8 +88,10 @@ The following section describes how to configure the watch process.
 
 #### Watch configuration
 
-> The default values should be fine in most cases.</br>
-> See [inotify-tools](https://github.com/inotify-tools/inotify-tools) for more details about `inotifywait` available flags.
+> The default values should be fine in most cases.
+>
+> See [inotify-tools](https://github.com/inotify-tools/inotify-tools) for more details about
+> `inotifywait` available flags.
 >
 > Booleans can be set to any value to be considered true.
 
@@ -89,10 +101,8 @@ The following section describes how to configure the watch process.
 | INOTIFY_CFG_EVENTS     | `modify delete delete_self` | Space-separated list of events to watch                             |
 | INOTIFY_CFG_EXCLUDE    | -                           | Exclude a subset of files using a POSIX regex pattern               |
 | INOTIFY_CFG_EXCLUDEI   | -                           | Same as `INOTIFY_CFG_EXCLUDE` but case insensitive                  |
-| INOTIFY_CFG_FORMAT     | `%T %w %e %f`               | The formatting pattern used to emit events                          |
 | INOTIFY_CFG_INCLUDE    | -                           | Include a subset of files using a POSIX regex pattern               |
 | INOTIFY_CFG_INCLUDEI   | -                           | Same as `INOTIFY_CFG_INCLUDE` but case insensitive                  |
-| INOTIFY_CFG_NO_NEWLINE | false                       | (bool) Remove newline from the emmited event                        |
 | INOTIFY_CFG_QUIET      | true                        | (bool) Suppress inotifywait logging                                 |
 | INOTIFY_CFG_RECURSIVE  | false                       | (bool) Watch all subdirectories with unlimited depth                |
 | INOTIFY_CFG_TIMEFMT    | `%H:%M:%S`                  | The strftime-compatible pattern used to display %T in emitted event |
@@ -102,7 +112,9 @@ The following section describes how to configure the watch process.
 
 #### Kubernetes
 
-The following example defines a `Pod` containing an application container and an `inotify` sidecar that will be used to trigger a server reload whenever the mounted configuration file (here a shared `ConfigMap`) is updated.
+The following example defines a `Pod` containing an application container and an `inotify` sidecar
+that will be used to trigger a server reload whenever the mounted configuration file (here a shared
+`ConfigMap`) is updated.
 
 ```yaml
 ---

--- a/scripts/inotifywait.sh
+++ b/scripts/inotifywait.sh
@@ -9,7 +9,6 @@ SCRIPT="${1}"; shift
 
 # bool accepted values: "true", "false"
 INOTIFY_CFG_CSV="${INOTIFY_CFG_CSV:-"false"}"
-INOTIFY_CFG_NO_NEWLINE="${INOTIFY_CFG_NO_NEWLINE:-"false"}"
 INOTIFY_CFG_QUIET="${INOTIFY_CFG_QUIET:-"true"}"
 INOTIFY_CFG_RECURSIVE="${INOTIFY_CFG_RECURSIVE:-"false"}"
 # variables set to "-" are ignored
@@ -18,45 +17,48 @@ INOTIFY_CFG_EXCLUDEI="${INOTIFY_CFG_EXCLUDEI:-"-"}"
 INOTIFY_CFG_INCLUDE="${INOTIFY_CFG_INCLUDE:-"-"}"
 INOTIFY_CFG_INCLUDEI="${INOTIFY_CFG_INCLUDEI:-"-"}"
 INOTIFY_CFG_EVENTS="${INOTIFY_CFG_EVENTS:-"modify delete delete_self"}"
-INOTIFY_CFG_FORMAT="${INOTIFY_CFG_FORMAT:-"%T %w %e %f"}"
 INOTIFY_CFG_TIMEFMT="${INOTIFY_CFG_TIMEFMT:-"%H:%M:%S"}"
 INOTIFY_CFG_TIMEOUT="${INOTIFY_CFG_TIMEOUT:-"-"}"
 
-function log { [ "${INOTIFY_QUIET}" != "true" ] && echo "${@}"; }
+function log { [ "${INOTIFY_QUIET}" != "true" ] && echo "[$(date -Iseconds)] ${*}"; }
 
-function join { local args=(${@:2}); printf -- "${1}%s" "${args[@]}"; }
+function join { printf -- "${1}%s" "${@:2}"; }
 function setboolflag { [ "${2}" = "true" ] && echo "${1}"; }
 function setflag { [ "${2}" != "-" ] && printf "%s=%s" "${1}" "${2}"; }
 
 function watch {
+    IFS=" " read -r -a cfg_events <<< "${INOTIFY_CFG_EVENTS}"
+    log "Watching events '${cfg_events[*]}' for '${TARGET}'"
+
     inotifywait --monitor \
+        --no-newline \
+        --format "%T%0%w%0%e%0%f%0" \
         "$(setboolflag --csv        "${INOTIFY_CFG_CSV}")"        \
-        "$(setboolflag --no-newline "${INOTIFY_CFG_NO_NEWLINE}")" \
         "$(setboolflag --quiet      "${INOTIFY_CFG_QUIET}")"      \
         "$(setboolflag --recursive  "${INOTIFY_CFG_RECURSIVE}")"  \
         "$(setflag     --exclude    "${INOTIFY_CFG_EXCLUDE}")"    \
         "$(setflag     --excludei   "${INOTIFY_CFG_EXCLUDEI}")"   \
         "$(setflag     --include    "${INOTIFY_CFG_INCLUDE}")"    \
         "$(setflag     --includei   "${INOTIFY_CFG_INCLUDEI}")"   \
-        "$(setflag     --format     "${INOTIFY_CFG_FORMAT}")"     \
         "$(setflag     --timefmt    "${INOTIFY_CFG_TIMEFMT}")"    \
         "$(setflag     --timeout    "${INOTIFY_CFG_TIMEOUT}")"    \
-        $(join " -e " ${INOTIFY_CFG_EVENTS}) \
-        "${TARGET}" | \
-        while read events; do
-            log "New event detected in '${TARGET}'"
-            "${SCRIPT}" ${events}
+        "${cfg_events[@]/#/-e}" \
+        "$(realpath "${TARGET}")" | while
+            IFS= read -r -d '' time && \
+            IFS= read -r -d '' watched && \
+            IFS= read -r -d '' events && \
+            IFS= read -r -d '' file; do
+            log "New event (${events}) detected for '${watched}' (time:${time} file:'${file}')"
+            "$(realpath "${SCRIPT}")" "${time}" "${watched}" "${events}" "${file}"
         done
 }
 
 while true; do
     if [ ! -e "${TARGET}" ]; then
-        log "Waiting for ${TARGET} to appear ..."
+        log "Waiting for '${TARGET}' to appear..."
         sleep 1
         continue
     fi
-
-    log "Watching events for '${TARGET}'"
 
     watch
 done


### PR DESCRIPTION
Use null delimiters between fields returned by inotifywait.

Remove the possibility to configure `--format` and `--no-newline`. Instead, we make the script API deterministic by always passing the 4 possible arguments from inotifywait: time, watched file/dir, events and target file (when watching a directory).

This is a breaking change, although no changes when the default value for `INOTIFY_CFG_FORMAT` and `INOTIFY_CFG_NO_NEWLINE` were used.

Fixes: #7